### PR TITLE
6.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,13 @@ Note: Even though the entire git development history isn't available on github, 
 [Friendly Release Notes](https://wpclouddeploy.com/category/release-notes/)
 
 ## Change Log ##
+6.1.1
+----
+* Fix: Fix null return for command result in WPCD_COMMAND_LOG class
+* Fix: Add checks for order object validity in WooCommerce item processing methods
+* Fix: potential null return for command log ID in WPCD_COMMAND_LOG class
 6.1.0
+----
 * Tweak: Always include the Imagick module in the PHP stack installation for all supported versions, removing Ubuntu version-specific conditions.
 * Implement high-performance command logging with DVICDCommandLogsTable integration
 * Refactor InitDviSetting to enhance high performance settings and improve code readability

--- a/includes/core/apps/class-wpcd-woocommerce.php
+++ b/includes/core/apps/class-wpcd-woocommerce.php
@@ -42,14 +42,16 @@ class WPCD_WOOCOMMERCE {
 	 */
 	protected function does_order_contain_item_of_type( $order, $item_type ) {
 		$found = false;
-		$items = $order->get_items();
-		foreach ( $items as $item ) {
-			$product_id = $item->get_product_id();
-			$product_id = apply_filters( 'wpcd_does_order_contain_item_of_type_product_id', $product_id, $item );
-			$is_type    = get_post_meta( $product_id, "wpcd_app_{$item_type}_product", true );
-			if ( 'yes' === $is_type ) {
-				$found = true;
-				break;
+		if ( is_object( $order ) ) {
+			$items = $order->get_items();
+			foreach ( $items as $item ) {
+				$product_id = $item->get_product_id();
+				$product_id = apply_filters( 'wpcd_does_order_contain_item_of_type_product_id', $product_id, $item );
+				$is_type    = get_post_meta( $product_id, "wpcd_app_{$item_type}_product", true );
+				if ( 'yes' === $is_type ) {
+					$found = true;
+					break;
+				}
 			}
 		}
 
@@ -75,6 +77,8 @@ class WPCD_WOOCOMMERCE {
 	 */
 	protected function does_order_suppress_thank_you_notice( $order, $item_type ) {
 		$return = true;
+		if ( is_object( $order ) ) {
+
 		$items  = $order->get_items();
 		foreach ( $items as $item ) {
 			$product_id = $item->get_product_id();
@@ -88,6 +92,7 @@ class WPCD_WOOCOMMERCE {
 				}
 			}
 		}
+	}
 
 		return apply_filters( 'wpcd_does_order_suppress_thank_you_notice', $return );
 	}
@@ -129,6 +134,7 @@ class WPCD_WOOCOMMERCE {
 	protected function get_unique_products_on_order( $order ) {
 
 		$return = array();
+		if ( is_object( $order ) ) {
 
 		$items = $order->get_items();
 		foreach ( $items as $item ) {
@@ -138,6 +144,7 @@ class WPCD_WOOCOMMERCE {
 				array_push( $return, $product_id );
 			}
 		}
+	}
 
 		return apply_filters( 'get_unique_products_on_order', $return );
 

--- a/includes/core/class-wpcd-posts-command-log.php
+++ b/includes/core/class-wpcd-posts-command-log.php
@@ -350,7 +350,8 @@ class WPCD_COMMAND_LOG extends WPCD_POSTS_LOG {
 	public static function get_command_log( $id ) {
 		if(wpcd_get_early_option('dvi_high_performance_command_logs')){
 			$dvicd_command_logs = new DVICDCommandLogsTable;
-			return $dvicd_command_logs->where('id',$id)->first()?->command_result;
+			$log = $dvicd_command_logs->where('id', $id)->first();
+			return $log ? $log->command_result : null;
 		}
 
 		return get_post_meta( $id, 'command_result', true );

--- a/includes/core/class-wpcd-posts-command-log.php
+++ b/includes/core/class-wpcd-posts-command-log.php
@@ -371,7 +371,8 @@ class WPCD_COMMAND_LOG extends WPCD_POSTS_LOG {
 			if ($count !== 1) {
 				return new \WP_Error("Command $name for $id has " . $count . ' instances');
 			}
-			return $command_logs->first()?->id;
+			$first_log = $command_logs->first();
+			return $first_log ? $first_log->id : null;
 		}
 
 


### PR DESCRIPTION
* Fix: Fix null return for command result in WPCD_COMMAND_LOG class
* Fix: Add checks for order object validity in WooCommerce item processing methods
* Fix: potential null return for command log ID in WPCD_COMMAND_LOG class
